### PR TITLE
Re-enable strict mode after move of pack-checker step

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ build:
     uv run generator/generate_ap_item_mappings.py
     # Map generation is slow and unlikely to change. Only run if needed.
     test -d tracker/images/maps || uv run generator/generate_map_images.py
-    uv run pack-checker tracker
+    uv run pack-checker --batch --strict tracker
 
 # Build the pack and install to local PopTracker
 [working-directory("tracker")]


### PR DESCRIPTION
Also force batch mode for Linux/Windows parity.