### PR TITLE
Use diff instead of cmp for JSON format check

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,6 @@ or come with Git Bash on Windows.
 
 Recipe: check
 
-If an initial run error produces something like
-`cmp: EOF on ‘./tracker/layouts/items_layout.json’ after byte 9012, in line 299`,
-make sure you files end with an empty newline character
-(e.g. If you have a JSON file `{}`, make sure it actually looks like `{}\n`).
-
 `just --fmt --unstable --check` may produce a `justfile` which exactly matches
 to the human eye but has Windows/Linux differences. You can run
 `just --fmt--unstable` manually to produce an exactly matching file

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ check:
     uv run ruff check
     uv run ruff format --check
     uv run mypy .
-    fd -e json -x sh -c 'jq {{ JQ_FORMAT_ARGS }} . {} | cmp {}'
+    fd -e json -x sh -c 'jq {{ JQ_FORMAT_ARGS }} . {} | diff -u --color=always {} -'
     just --fmt --unstable --check
     uv run rumdl check
 


### PR DESCRIPTION
Fixes #15

# Example

```
$ truncate -s -1 tracker/items/checkpoints.json
$ just check
uv run ruff check
All checks passed!
uv run ruff format --check
5 files already formatted
uv run mypy .
Success: no issues found in 5 source files
fd -e json -x sh -c 'jq --indent 4 . {} | diff -u --color=always {} -'
--- ./tracker/items/checkpoints.json    2026-02-28 17:43:52.158720946 +0100
+++ -   2026-02-28 17:53:24.025407017 +0100
@@ -419,4 +419,4 @@
         "disabled_img_mods": "saturation|0|bt601,brightness|0.33",
         "codes": "farewell-farewell"
     }
-]
\ No newline at end of file
+]
error: Recipe `check` failed on line 11 with exit code 1
```